### PR TITLE
add CI for pull requests, deploy docs when main is updated

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,6 +1,9 @@
 name: build and deploy mathlib4 docs
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
   workflow_dispatch:
   schedule:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,6 +1,7 @@
 name: build and deploy mathlib4 docs
 
 on:
+  pull_request:
   workflow_dispatch:
   schedule:
     - cron: '0 */8 * * *' # every 8 hours
@@ -108,6 +109,7 @@ jobs:
           path: 'workaround/.lake/build/doc'
 
       - name: Deploy to GitHub Pages
+        if: github.ref == 'refs/heads/main'
         id: deployment
         uses: actions/deploy-pages@v4
 


### PR DESCRIPTION
Note that this uses the `pull_request` event so it runs the code in the PR branch and does not have access to repo secrets (I don't think there are any relevant ones here though). We need to be extra careful here with external PRs because we run on self-hosted runners.